### PR TITLE
Add CSP rule

### DIFF
--- a/example/pages/_app.tsx
+++ b/example/pages/_app.tsx
@@ -6,5 +6,5 @@ class Application extends App {}
 
 export default withSecureHeaders({
   forceHTTPSRedirect: [true, { maxAge: 60 * 60 * 24 * 4, includeSubDomains: true }],
-  referrerGuard: "same-origin",
+  referrerPolicy: "same-origin",
 })(Application);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,10 @@ import * as rules from "./rules";
 import { default as withSecureHeaders, createHeadersObject } from "./index";
 
 describe("createHeadersObject", () => {
+  let contentSecurityPolicyHeaderCreatorSpy: jest.SpyInstance<
+    ReturnType<typeof rules.createContentSecurityPolicyHeader>,
+    Parameters<typeof rules.createContentSecurityPolicyHeader>
+  >;
   let expectCTHeaderCreatorSpy: jest.SpyInstance<
     ReturnType<typeof rules.createExpectCTHeader>,
     Parameters<typeof rules.createExpectCTHeader>
@@ -35,6 +39,7 @@ describe("createHeadersObject", () => {
 
   describe("calling rules", () => {
     beforeAll(() => {
+      contentSecurityPolicyHeaderCreatorSpy = jest.spyOn(rules, "createContentSecurityPolicyHeader");
       expectCTHeaderCreatorSpy = jest.spyOn(rules, "createExpectCTHeader");
       forceHTTPSRedirectHeaderCreatorSpy = jest.spyOn(rules, "createForceHTTPSRedirectHeader");
       frameGuardHeaderCreatorSpy = jest.spyOn(rules, "createFrameGuardHeader");
@@ -46,6 +51,7 @@ describe("createHeadersObject", () => {
 
     it("should call each rules and give proper options", () => {
       const dummyOptions: Parameters<typeof createHeadersObject>[0] = {
+        contentSecurityPolicy: { directives: { scriptSrc: "'self'" } },
         expectCT: [true, { maxAge: 123, enforce: true, reportURI: "https://example.example.com" }],
         forceHTTPSRedirect: [true, { maxAge: 123, preload: true }],
         frameGuard: ["allow-from", { uri: "https://example.example.com" }],
@@ -55,6 +61,7 @@ describe("createHeadersObject", () => {
       };
       createHeadersObject(dummyOptions);
 
+      expect(contentSecurityPolicyHeaderCreatorSpy).toBeCalledWith(dummyOptions.contentSecurityPolicy);
       expect(expectCTHeaderCreatorSpy).toBeCalledWith(dummyOptions.expectCT);
       expect(forceHTTPSRedirectHeaderCreatorSpy).toBeCalledWith(dummyOptions.forceHTTPSRedirect);
       expect(frameGuardHeaderCreatorSpy).toBeCalledWith(dummyOptions.frameGuard);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -55,25 +55,12 @@ describe("createHeadersObject", () => {
       };
       createHeadersObject(dummyOptions);
 
-      expect(expectCTHeaderCreatorSpy).toBeCalledTimes(1);
       expect(expectCTHeaderCreatorSpy).toBeCalledWith(dummyOptions.expectCT);
-
-      expect(forceHTTPSRedirectHeaderCreatorSpy).toBeCalledTimes(1);
       expect(forceHTTPSRedirectHeaderCreatorSpy).toBeCalledWith(dummyOptions.forceHTTPSRedirect);
-
-      expect(frameGuardHeaderCreatorSpy).toBeCalledTimes(1);
       expect(frameGuardHeaderCreatorSpy).toBeCalledWith(dummyOptions.frameGuard);
-
-      expect(noopenHeaderCreatorSpy).toBeCalledTimes(1);
       expect(noopenHeaderCreatorSpy).toBeCalledWith(dummyOptions.noopen);
-
-      expect(nosniffHeaderCreatorSpy).toBeCalledTimes(1);
       expect(nosniffHeaderCreatorSpy).toBeCalledWith(dummyOptions.nosniff);
-
-      expect(referrerPolicyHeaderCreatorSpy).toBeCalledTimes(1);
       expect(referrerPolicyHeaderCreatorSpy).toBeCalledWith(dummyOptions.referrerPolicy);
-
-      expect(xssProtectionHeaderCreatorSpy).toBeCalledTimes(1);
       expect(xssProtectionHeaderCreatorSpy).toBeCalledWith(dummyOptions.xssProtection);
     });
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -24,9 +24,9 @@ describe("createHeadersObject", () => {
     ReturnType<typeof rules.createNosniffHeader>,
     Parameters<typeof rules.createNosniffHeader>
   >;
-  let referrerGuardHeaderCreatorSpy: jest.SpyInstance<
-    ReturnType<typeof rules.createReferrerGuardHeader>,
-    Parameters<typeof rules.createReferrerGuardHeader>
+  let referrerPolicyHeaderCreatorSpy: jest.SpyInstance<
+    ReturnType<typeof rules.createReferrerPolicyHeader>,
+    Parameters<typeof rules.createReferrerPolicyHeader>
   >;
   let xssProtectionHeaderCreatorSpy: jest.SpyInstance<
     ReturnType<typeof rules.createXSSProtectionHeader>,
@@ -40,7 +40,7 @@ describe("createHeadersObject", () => {
       frameGuardHeaderCreatorSpy = jest.spyOn(rules, "createFrameGuardHeader");
       noopenHeaderCreatorSpy = jest.spyOn(rules, "createNoopenHeader");
       nosniffHeaderCreatorSpy = jest.spyOn(rules, "createNosniffHeader");
-      referrerGuardHeaderCreatorSpy = jest.spyOn(rules, "createReferrerGuardHeader");
+      referrerPolicyHeaderCreatorSpy = jest.spyOn(rules, "createReferrerPolicyHeader");
       xssProtectionHeaderCreatorSpy = jest.spyOn(rules, "createXSSProtectionHeader");
     });
 
@@ -70,8 +70,8 @@ describe("createHeadersObject", () => {
       expect(nosniffHeaderCreatorSpy).toBeCalledTimes(1);
       expect(nosniffHeaderCreatorSpy).toBeCalledWith(dummyOptions.nosniff);
 
-      expect(referrerGuardHeaderCreatorSpy).toBeCalledTimes(1);
-      expect(referrerGuardHeaderCreatorSpy).toBeCalledWith(dummyOptions.referrerGuard);
+      expect(referrerPolicyHeaderCreatorSpy).toBeCalledTimes(1);
+      expect(referrerPolicyHeaderCreatorSpy).toBeCalledWith(dummyOptions.referrerPolicy);
 
       expect(xssProtectionHeaderCreatorSpy).toBeCalledTimes(1);
       expect(xssProtectionHeaderCreatorSpy).toBeCalledWith(dummyOptions.xssProtection);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ type Options = Partial<{
    * This is to set "Referrer-Policy" header and it's to prevent to be got referrer by other servers.
    * You can specify one or more values for legacy browsers which does not support a specific value.
    */
-  referrerGuard: rules.ReferrerGuardOption;
+  referrerPolicy: rules.ReferrerPolicyOption;
   /**
    * This is to set "X-XSS-Protection" header and it's to prevent XSS attacks.
    * If you specify `"sanitize"` , this sets `"1"` to the header and browsers will sanitize unsafe area.
@@ -55,7 +55,7 @@ export const createHeadersObject = (options: Options = {}) => {
     rules.createFrameGuardHeader(options.frameGuard),
     rules.createNoopenHeader(options.noopen),
     rules.createNosniffHeader(options.nosniff),
-    rules.createReferrerGuardHeader(options.referrerGuard),
+    rules.createReferrerPolicyHeader(options.referrerPolicy),
     rules.createXSSProtectionHeader(options.xssProtection),
   ].forEach((header) => {
     if (header.value == undefined) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export const createHeadersObject = (options: Options = {}) => {
     rules.createReferrerPolicyHeader(options.referrerPolicy),
     rules.createXSSProtectionHeader(options.xssProtection),
   ].forEach((header) => {
+    if (header == undefined) return;
     if (header.value == undefined) return;
 
     newHeaders[header.name] = header.value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import * as rules from "./rules";
 
 type Options = Partial<{
   /**
+   * This is to set "Content-Security-Policy" or "Content-Security-Policy-Report-Only" header and it's to prevent to load and
+   * execute non-allowed resources.
+   */
+  contentSecurityPolicy: rules.ContentSecurityPolicyOption;
+  /**
    * This is to set "Expect-CT" header and it's to tell browsers to expect Certificate Transparency.
    */
   expectCT: rules.ExpectCTOption;
@@ -50,6 +55,7 @@ export const createHeadersObject = (options: Options = {}) => {
   const newHeaders: Record<string, string> = {};
 
   [
+    rules.createContentSecurityPolicyHeader(options.contentSecurityPolicy),
     rules.createExpectCTHeader(options.expectCT),
     rules.createForceHTTPSRedirectHeader(options.forceHTTPSRedirect),
     rules.createFrameGuardHeader(options.frameGuard),

--- a/src/rules/content-security-policy.spec.ts
+++ b/src/rules/content-security-policy.spec.ts
@@ -1,0 +1,469 @@
+import { wrapArray } from "./shared";
+import {
+  createContentSecurityPolicyHeader,
+  convertFetchDirectiveToString,
+  createContentSecurityPolicyOptionHeaderValue,
+  createDirectiveValue,
+  convertDocumentDirectiveToString,
+  getProperHeaderName,
+  convertReportingDirectiveToString,
+} from "./content-security-policy";
+
+describe("createContentSecurityPolicyHeader", () => {
+  context("when giving undefined", () => {
+    it("should return undefined", () => {
+      expect(createContentSecurityPolicyHeader()).toBeUndefined();
+    });
+  });
+
+  context("when giving false", () => {
+    it("should return undefined", () => {
+      expect(createContentSecurityPolicyHeader(false)).toBeUndefined();
+    });
+  });
+
+  context("when giving an object", () => {
+    const dummyOption: Parameters<typeof createContentSecurityPolicyOptionHeaderValue>[0] = {
+      directives: { childSrc: "'self'", objectSrc: "https://example.com" },
+    };
+
+    let properHeaderNameGetterMock: jest.Mock<ReturnType<typeof getProperHeaderName>, Parameters<typeof getProperHeaderName>>;
+    let headerValueCreatorMock: jest.Mock<
+      ReturnType<typeof createContentSecurityPolicyOptionHeaderValue>,
+      Parameters<typeof createContentSecurityPolicyOptionHeaderValue>
+    >;
+
+    beforeAll(() => {
+      properHeaderNameGetterMock = jest.fn(getProperHeaderName);
+      headerValueCreatorMock = jest.fn(createContentSecurityPolicyOptionHeaderValue);
+    });
+
+    it('should call the second argument function and return a value from the function as object\'s "name" property', () => {
+      const dummyValue: any = "dummy-value";
+      properHeaderNameGetterMock.mockReturnValue(dummyValue);
+      expect(createContentSecurityPolicyHeader(dummyOption, properHeaderNameGetterMock)).toHaveProperty("name", dummyValue);
+    });
+
+    it('should call the third argument function and return a value from the function as object\'s "value" property', () => {
+      const dummyValue = "dummy-value";
+      headerValueCreatorMock.mockReturnValue(dummyValue);
+
+      expect(createContentSecurityPolicyHeader(dummyOption, undefined, headerValueCreatorMock)).toHaveProperty(
+        "value",
+        dummyValue,
+      );
+    });
+  });
+});
+
+describe("createContentSecurityPolicyOptionHeaderValue", () => {
+  context("when giving undefined", () => {
+    it("should return undefined", () => {
+      expect(createContentSecurityPolicyOptionHeaderValue()).toBeUndefined();
+    });
+  });
+
+  context("when giving false", () => {
+    it("should return undefined", () => {
+      expect(createContentSecurityPolicyOptionHeaderValue(false)).toBeUndefined();
+    });
+  });
+
+  context("when giving an object", () => {
+    const dummyOption: Parameters<typeof createContentSecurityPolicyOptionHeaderValue>[0] = {
+      directives: { childSrc: "'self'", objectSrc: "https://example.com" },
+    };
+
+    let fetchDirectiveToStringConverterMock: jest.Mock<
+      ReturnType<typeof convertFetchDirectiveToString>,
+      Parameters<typeof convertFetchDirectiveToString>
+    >;
+    let documentDirectiveToStringConverterMock: jest.Mock<
+      ReturnType<typeof convertDocumentDirectiveToString>,
+      Parameters<typeof convertDocumentDirectiveToString>
+    >;
+    let reportingDirectiveToStringConverterMock: jest.Mock<
+      ReturnType<typeof convertReportingDirectiveToString>,
+      Parameters<typeof convertReportingDirectiveToString>
+    >;
+
+    beforeAll(() => {
+      fetchDirectiveToStringConverterMock = jest.fn(convertFetchDirectiveToString);
+      documentDirectiveToStringConverterMock = jest.fn(convertDocumentDirectiveToString);
+      reportingDirectiveToStringConverterMock = jest.fn(convertReportingDirectiveToString);
+    });
+
+    it("should call the second argument with directives", () => {
+      createContentSecurityPolicyOptionHeaderValue(dummyOption, fetchDirectiveToStringConverterMock);
+
+      expect(fetchDirectiveToStringConverterMock).toBeCalledWith(dummyOption.directives);
+    });
+
+    it("should call the third argument with directives", () => {
+      createContentSecurityPolicyOptionHeaderValue(dummyOption, undefined, documentDirectiveToStringConverterMock);
+
+      expect(documentDirectiveToStringConverterMock).toBeCalledWith(dummyOption.directives);
+    });
+
+    it("should call the fourth argument with directives", () => {
+      createContentSecurityPolicyOptionHeaderValue(dummyOption, undefined, undefined, reportingDirectiveToStringConverterMock);
+
+      expect(reportingDirectiveToStringConverterMock).toBeCalledWith(dummyOption.directives);
+    });
+
+    it('should join directive strings using "; "', () => {
+      fetchDirectiveToStringConverterMock.mockReturnValue("dummy-value-1");
+      documentDirectiveToStringConverterMock.mockReturnValue("dummy-value-2");
+      reportingDirectiveToStringConverterMock.mockReturnValue("dummy-value-3");
+
+      expect(
+        createContentSecurityPolicyOptionHeaderValue(
+          dummyOption,
+          fetchDirectiveToStringConverterMock,
+          documentDirectiveToStringConverterMock,
+          reportingDirectiveToStringConverterMock,
+        ),
+      ).toBe("dummy-value-1; dummy-value-2; dummy-value-3");
+    });
+  });
+});
+
+describe("getProperHeaderName", () => {
+  context("when calling without arguments", () => {
+    it('should return "Content-Security-Policy"', () => {
+      expect(getProperHeaderName()).toBe("Content-Security-Policy");
+    });
+  });
+
+  context("when giving false", () => {
+    it('should return "Content-Security-Policy"', () => {
+      expect(getProperHeaderName(false)).toBe("Content-Security-Policy");
+    });
+  });
+
+  context("when giving true", () => {
+    it('should return "Content-Security-Policy-Report-Only"', () => {
+      expect(getProperHeaderName(true)).toBe("Content-Security-Policy-Report-Only");
+    });
+  });
+});
+
+describe("createDirectiveValue", () => {
+  let arrayWrapperMock: jest.Mock<any, any>;
+  beforeAll(() => {
+    arrayWrapperMock = jest.fn(wrapArray);
+  });
+
+  it("should join arguments using one half-space", () => {
+    const directiveName = "dummy-directive";
+    const values = ["1", "2", "3"];
+
+    expect(createDirectiveValue(directiveName, values)).toBe(`${directiveName} ${values.join(" ")}`);
+    expect(createDirectiveValue(directiveName, values[0])).toBe(`${directiveName} ${values[0]}`);
+  });
+
+  it("should call the third argument with the second argument", () => {
+    const directiveName = "dummy-directive";
+    const values = ["1", "2", "3"];
+    createDirectiveValue(directiveName, values, arrayWrapperMock);
+
+    expect(arrayWrapperMock).toBeCalledWith(values);
+  });
+});
+
+describe("convertFetchDirectiveToString", () => {
+  context("when giving undefined", () => {
+    it("should return an empty string", () => {
+      expect(convertFetchDirectiveToString()).toBe("");
+    });
+  });
+
+  context("when giving an empty object", () => {
+    it("should return an empty string", () => {
+      expect(convertFetchDirectiveToString({})).toBe("");
+    });
+  });
+
+  context('when giving an object which has "childSrc" property', () => {
+    it('should return value which includes "child-src"', () => {
+      expect(convertFetchDirectiveToString({ childSrc: "'self'" })).toBe("child-src 'self'");
+      expect(convertFetchDirectiveToString({ childSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "child-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "connectSrc" property', () => {
+    it('should return value which includes "connect-src"', () => {
+      expect(convertFetchDirectiveToString({ connectSrc: "'self'" })).toBe("connect-src 'self'");
+      expect(convertFetchDirectiveToString({ connectSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "connect-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "defaultSrc" property', () => {
+    it('should return value which includes "default-src"', () => {
+      expect(convertFetchDirectiveToString({ defaultSrc: "'self'" })).toBe("default-src 'self'");
+      expect(convertFetchDirectiveToString({ defaultSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "default-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "fontSrc" property', () => {
+    it('should return value which includes "font-src"', () => {
+      expect(convertFetchDirectiveToString({ fontSrc: "'self'" })).toBe("font-src 'self'");
+      expect(convertFetchDirectiveToString({ fontSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "font-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "frameSrc" property', () => {
+    it('should return value which includes "frame-src"', () => {
+      expect(convertFetchDirectiveToString({ frameSrc: "'self'" })).toBe("frame-src 'self'");
+      expect(convertFetchDirectiveToString({ frameSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "frame-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "imgSrc" property', () => {
+    it('should return value which includes "img-src"', () => {
+      expect(convertFetchDirectiveToString({ imgSrc: "'self'" })).toBe("img-src 'self'");
+      expect(convertFetchDirectiveToString({ imgSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "img-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "manifestSrc" property', () => {
+    it('should return value which includes "manifest-src"', () => {
+      expect(convertFetchDirectiveToString({ manifestSrc: "'self'" })).toBe("manifest-src 'self'");
+      expect(convertFetchDirectiveToString({ manifestSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "manifest-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "mediaSrc" property', () => {
+    it('should return value which includes "media-src"', () => {
+      expect(convertFetchDirectiveToString({ mediaSrc: "'self'" })).toBe("media-src 'self'");
+      expect(convertFetchDirectiveToString({ mediaSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "media-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "prefetchSrc" property', () => {
+    it('should return value which includes "prefetch-src"', () => {
+      expect(convertFetchDirectiveToString({ prefetchSrc: "'self'" })).toBe("prefetch-src 'self'");
+      expect(convertFetchDirectiveToString({ prefetchSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "prefetch-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "objectSrc" property', () => {
+    it('should return value which includes "object-src"', () => {
+      expect(convertFetchDirectiveToString({ objectSrc: "'self'" })).toBe("object-src 'self'");
+      expect(convertFetchDirectiveToString({ objectSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "object-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "scriptSrc" property', () => {
+    it('should return value which includes "script-src"', () => {
+      expect(convertFetchDirectiveToString({ scriptSrc: "'self'" })).toBe("script-src 'self'");
+      expect(convertFetchDirectiveToString({ scriptSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "script-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "scriptSrcElem" property', () => {
+    it('should return value which includes "script-src-elem"', () => {
+      expect(convertFetchDirectiveToString({ scriptSrcElem: "'self'" })).toBe("script-src-elem 'self'");
+      expect(convertFetchDirectiveToString({ scriptSrcElem: ["'self'", "https://www.example.com/"] })).toBe(
+        "script-src-elem 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "scriptSrcAttr" property', () => {
+    it('should return value which includes "script-src-attr"', () => {
+      expect(convertFetchDirectiveToString({ scriptSrcAttr: "'self'" })).toBe("script-src-attr 'self'");
+      expect(convertFetchDirectiveToString({ scriptSrcAttr: ["'self'", "https://www.example.com/"] })).toBe(
+        "script-src-attr 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "styleSrc" property', () => {
+    it('should return value which includes "style-src"', () => {
+      expect(convertFetchDirectiveToString({ styleSrc: "'self'" })).toBe("style-src 'self'");
+      expect(convertFetchDirectiveToString({ styleSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "style-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "styleSrcElem" property', () => {
+    it('should return value which includes "style-src-elem"', () => {
+      expect(convertFetchDirectiveToString({ styleSrcElem: "'self'" })).toBe("style-src-elem 'self'");
+      expect(convertFetchDirectiveToString({ styleSrcElem: ["'self'", "https://www.example.com/"] })).toBe(
+        "style-src-elem 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "styleSrcAttr" property', () => {
+    it('should return value which includes "style-src-attr"', () => {
+      expect(convertFetchDirectiveToString({ styleSrcAttr: "'self'" })).toBe("style-src-attr 'self'");
+      expect(convertFetchDirectiveToString({ styleSrcAttr: ["'self'", "https://www.example.com/"] })).toBe(
+        "style-src-attr 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "workerSrc" property', () => {
+    it('should return value which includes "worker-src"', () => {
+      expect(convertFetchDirectiveToString({ workerSrc: "'self'" })).toBe("worker-src 'self'");
+      expect(convertFetchDirectiveToString({ workerSrc: ["'self'", "https://www.example.com/"] })).toBe(
+        "worker-src 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context("when giving an object which has undefined", () => {
+    it("should ignore the properties", () => {
+      expect(convertFetchDirectiveToString({ childSrc: undefined, objectSrc: undefined, styleSrc: "'self'" })).toBe(
+        "style-src 'self'",
+      );
+    });
+  });
+
+  context("when giving an object which has one or more properties", () => {
+    it('should return value which includes their directive names joined "; "', () => {
+      expect(
+        convertFetchDirectiveToString({
+          childSrc: "'self'",
+          objectSrc: "https://example.com/",
+          styleSrc: "'unsafe-inline'",
+        }),
+      ).toBe("child-src 'self'; object-src https://example.com/; style-src 'unsafe-inline'");
+    });
+  });
+});
+
+describe("convertDocumentDirectiveToString", () => {
+  context("when giving undefined", () => {
+    it("should return an empty string", () => {
+      expect(convertDocumentDirectiveToString()).toBe("");
+    });
+  });
+
+  context("when giving an empty object", () => {
+    it("should return an empty string", () => {
+      expect(convertDocumentDirectiveToString({})).toBe("");
+    });
+  });
+
+  context('when giving an object which has "baseURI" property', () => {
+    it('should return value which includes "base-uri"', () => {
+      expect(convertDocumentDirectiveToString({ baseURI: "'self'" })).toBe("base-uri 'self'");
+      expect(convertDocumentDirectiveToString({ baseURI: ["'self'", "https://www.example.com/"] })).toBe(
+        "base-uri 'self' https://www.example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "pluginTypes" property', () => {
+    it('should return value which includes "plugin-types"', () => {
+      expect(convertDocumentDirectiveToString({ pluginTypes: "text/javascript" })).toBe("plugin-types text/javascript");
+      expect(convertDocumentDirectiveToString({ pluginTypes: ["text/javascript", "image/png"] })).toBe(
+        "plugin-types text/javascript image/png",
+      );
+    });
+  });
+
+  context('when giving an object which has "sandbox" property', () => {
+    it('should return value which includes "sandbox"', () => {
+      expect(convertDocumentDirectiveToString({ sandbox: true })).toBe("sandbox");
+      expect(convertDocumentDirectiveToString({ sandbox: "allow-forms" })).toBe("sandbox allow-forms");
+    });
+  });
+
+  context("when giving an object which has one or more properties", () => {
+    it('should return value which includes their directive names joined "; "', () => {
+      expect(
+        convertDocumentDirectiveToString({
+          baseURI: "'self'",
+          pluginTypes: ["text/javascript", "image/png"],
+          sandbox: true,
+        }),
+      ).toBe("base-uri 'self'; plugin-types text/javascript image/png; sandbox");
+    });
+  });
+});
+
+describe("convertReportingDirectiveToString", () => {
+  context("when giving undefined", () => {
+    it("should return an empty string", () => {
+      expect(convertReportingDirectiveToString()).toBe("");
+    });
+  });
+
+  context("when giving an empty object", () => {
+    it("should return an empty string", () => {
+      expect(convertReportingDirectiveToString({})).toBe("");
+    });
+  });
+
+  context('when giving an object which has "navigateTo" property', () => {
+    it('should return value which includes "navigate-to"', () => {
+      expect(convertReportingDirectiveToString({ navigateTo: "'self'" })).toBe("navigate-to 'self'");
+      expect(convertReportingDirectiveToString({ navigateTo: ["'self'", "https://example.com/"] })).toBe(
+        "navigate-to 'self' https://example.com/",
+      );
+    });
+  });
+
+  context('when giving an object which has "reportURI" property', () => {
+    it('should return value which includes "report-uri"', () => {
+      expect(convertReportingDirectiveToString({ reportURI: "https://example.com" })).toBe("report-uri https://example.com/");
+      expect(
+        convertReportingDirectiveToString({ reportURI: ["https://example.com", new URL("https://www.example.com")] }),
+      ).toBe("report-uri https://example.com/ https://www.example.com/");
+    });
+  });
+
+  context('when giving an object which has "reportTo" property', () => {
+    it('should return value which includes "report-to"', () => {
+      expect(convertReportingDirectiveToString({ reportTo: { foo: { bar: 123 } } })).toBe('report-to {"foo":{"bar":123}}');
+    });
+
+    it('should call "JSON.stinrigfy" function', () => {
+      const jsonStringifySpy = jest.spyOn(JSON, "stringify");
+
+      const value = { foo: { bar: 123 } };
+      convertReportingDirectiveToString({ reportTo: value });
+
+      expect(jsonStringifySpy).toBeCalledWith(value);
+    });
+  });
+
+  context("when giving an object which has one or more properties", () => {
+    it('should return value which includes their directive names joined "; "', () => {
+      expect(
+        convertReportingDirectiveToString({
+          navigateTo: "'self'",
+          reportURI: new URL("https://example.com"),
+          reportTo: { foo: { bar: 123 } },
+        }),
+      ).toBe('navigate-to \'self\'; report-uri https://example.com/; report-to {"foo":{"bar":123}}');
+    });
+  });
+});

--- a/src/rules/content-security-policy.spec.ts
+++ b/src/rules/content-security-policy.spec.ts
@@ -1,12 +1,12 @@
 import { wrapArray } from "./shared";
 import {
-  createContentSecurityPolicyHeader,
+  convertDocumentDirectiveToString,
   convertFetchDirectiveToString,
+  convertReportingDirectiveToString,
+  createContentSecurityPolicyHeader,
   createContentSecurityPolicyOptionHeaderValue,
   createDirectiveValue,
-  convertDocumentDirectiveToString,
   getProperHeaderName,
-  convertReportingDirectiveToString,
 } from "./content-security-policy";
 
 describe("createContentSecurityPolicyHeader", () => {

--- a/src/rules/content-security-policy.ts
+++ b/src/rules/content-security-policy.ts
@@ -60,7 +60,7 @@ const headerName = "Content-Security-Policy";
 const reportOnlyHeaderName = "Content-Security-Policy-Report-Only";
 const directiveValueSepartor = "; ";
 
-export const getProperHeaderName = (reportOnly: boolean = false) => (reportOnly ? reportOnlyHeaderName : headerName);
+export const getProperHeaderName = (reportOnly = false) => (reportOnly ? reportOnlyHeaderName : headerName);
 export const createDirectiveValue = <T>(directiveName: string, value: T | T[], arrayWrapper = wrapArray) => {
   const values = arrayWrapper(value);
 

--- a/src/rules/content-security-policy.ts
+++ b/src/rules/content-security-policy.ts
@@ -1,0 +1,162 @@
+import { ResponseHeader } from "../shared";
+import { encodeStrictURI, wrapArray } from "./shared";
+
+type DirectiveSource = string | string[];
+type PluginTypes = string | string[];
+type Sandbox =
+  | true
+  | "allow-downloads-without-user-activation"
+  | "allow-forms"
+  | "allow-modals"
+  | "allow-orientation-lock"
+  | "allow-pointer-lock"
+  | "allow-popups"
+  | "allow-popups-to-escape-sandbox"
+  | "allow-presentation"
+  | "allow-same-origin"
+  | "allow-scripts"
+  | "allow-storage-access-by-user-activation"
+  | "allow-top-navigation"
+  | "allow-top-navigation-by-user-activation";
+
+type FetchDirective = {
+  childSrc: DirectiveSource;
+  connectSrc: DirectiveSource;
+  defaultSrc: DirectiveSource;
+  fontSrc: DirectiveSource;
+  frameSrc: DirectiveSource;
+  imgSrc: DirectiveSource;
+  manifestSrc: DirectiveSource;
+  mediaSrc: DirectiveSource;
+  prefetchSrc: DirectiveSource;
+  objectSrc: DirectiveSource;
+  scriptSrc: DirectiveSource;
+  scriptSrcElem: DirectiveSource;
+  scriptSrcAttr: DirectiveSource;
+  styleSrc: DirectiveSource;
+  styleSrcElem: DirectiveSource;
+  styleSrcAttr: DirectiveSource;
+  workerSrc: DirectiveSource;
+};
+type DocumentDirective = {
+  baseURI: DirectiveSource;
+  pluginTypes: PluginTypes;
+  sandbox: Sandbox;
+};
+type ReportingDirective = {
+  navigateTo: DirectiveSource;
+  reportURI: string | URL | (string | URL)[];
+  reportTo: object;
+};
+
+export type ContentSecurityPolicyOption =
+  | false
+  | {
+      directives: Partial<FetchDirective> & Partial<DocumentDirective> & Partial<ReportingDirective>;
+      reportOnly?: boolean;
+    };
+
+const headerName = "Content-Security-Policy";
+const reportOnlyHeaderName = "Content-Security-Policy-Report-Only";
+const directiveValueSepartor = "; ";
+
+export const getProperHeaderName = (reportOnly: boolean = false) => (reportOnly ? reportOnlyHeaderName : headerName);
+export const createDirectiveValue = <T>(directiveName: string, value: T | T[], arrayWrapper = wrapArray) => {
+  const values = arrayWrapper(value);
+
+  return `${directiveName} ${values.join(" ")}`;
+};
+
+const fetchDirectiveNamesByKey: Record<keyof FetchDirective, string> = {
+  childSrc: "child-src",
+  connectSrc: "connect-src",
+  defaultSrc: "default-src",
+  fontSrc: "font-src",
+  frameSrc: "frame-src",
+  imgSrc: "img-src",
+  manifestSrc: "manifest-src",
+  mediaSrc: "media-src",
+  prefetchSrc: "prefetch-src",
+  objectSrc: "object-src",
+  scriptSrc: "script-src",
+  scriptSrcElem: "script-src-elem",
+  scriptSrcAttr: "script-src-attr",
+  styleSrc: "style-src",
+  styleSrcElem: "style-src-elem",
+  styleSrcAttr: "style-src-attr",
+  workerSrc: "worker-src",
+};
+export const convertFetchDirectiveToString = (directive?: Partial<FetchDirective>) => {
+  if (directive == undefined) return "";
+
+  const strings: string[] = [];
+  Object.entries(directive).forEach(([key, value]) => {
+    if (value == undefined) return;
+
+    const directiveName = fetchDirectiveNamesByKey[key as keyof FetchDirective];
+    strings.push(createDirectiveValue(directiveName, wrapArray(value)));
+  });
+
+  return strings.join(directiveValueSepartor);
+};
+
+export const convertDocumentDirectiveToString = (directive?: Partial<DocumentDirective>) => {
+  if (directive == undefined) return "";
+
+  const strings: string[] = [];
+
+  if (directive.baseURI != undefined) strings.push(createDirectiveValue("base-uri", wrapArray(directive.baseURI)));
+  if (directive.pluginTypes != undefined) strings.push(createDirectiveValue("plugin-types", wrapArray(directive.pluginTypes)));
+  if (directive.sandbox != undefined) {
+    const directiveName = "sandbox";
+    const value = directive.sandbox === true ? directiveName : createDirectiveValue(directiveName, directive.sandbox);
+    strings.push(value);
+  }
+
+  return strings.join(directiveValueSepartor);
+};
+
+export const convertReportingDirectiveToString = (directive?: Partial<ReportingDirective>) => {
+  if (directive == undefined) return "";
+
+  const strings: string[] = [];
+
+  if (directive.navigateTo != undefined) strings.push(createDirectiveValue("navigate-to", wrapArray(directive.navigateTo)));
+  if (directive.reportURI != undefined) {
+    const reportURI = wrapArray(directive.reportURI).map(encodeStrictURI);
+    strings.push(createDirectiveValue("report-uri", reportURI));
+  }
+  if (directive.reportTo != undefined) strings.push(createDirectiveValue("report-to", JSON.stringify(directive.reportTo)));
+
+  return strings.join(directiveValueSepartor);
+};
+
+export const createContentSecurityPolicyOptionHeaderValue = (
+  option?: ContentSecurityPolicyOption,
+  fetchDirectiveToStringConverter = convertFetchDirectiveToString,
+  documentDirectiveToStringConverter = convertDocumentDirectiveToString,
+  reportingDirectiveToStringConverter = convertReportingDirectiveToString,
+): string | undefined => {
+  if (option == undefined) return;
+  if (option === false) return;
+
+  return [
+    fetchDirectiveToStringConverter(option.directives),
+    documentDirectiveToStringConverter(option.directives),
+    reportingDirectiveToStringConverter(option.directives),
+  ].join(directiveValueSepartor);
+};
+
+export const createContentSecurityPolicyHeader = (
+  option?: ContentSecurityPolicyOption,
+  properHeaderNameGetter = getProperHeaderName,
+  headerValueCreator = createContentSecurityPolicyOptionHeaderValue,
+): ResponseHeader | undefined => {
+  if (option == undefined) return;
+  if (option === false) return;
+
+  const headerName = properHeaderNameGetter(option.reportOnly);
+  const value = headerValueCreator(option);
+
+  return { name: headerName, value };
+};

--- a/src/rules/expect-ct.spec.ts
+++ b/src/rules/expect-ct.spec.ts
@@ -1,3 +1,4 @@
+import { encodeStrictURI } from "./shared";
 import { createExpectCTHeader, createExpectCTHeaderValue } from "./expect-ct";
 
 describe("createExpectCTHeader", () => {
@@ -89,72 +90,22 @@ describe("createExpectCTHeaderValue", () => {
   });
 
   context('when specifying "reportURI" option', () => {
-    context("the option is string", () => {
-      context("the option is valid URI", () => {
-        it('should return "allow-from" string and escaped URI', () => {
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://example.com" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://example.com/`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://example.com/" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://example.com/`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://example.com/foo-bar" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://example.com/foo-bar`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://example.com/foo-bar/" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://example.com/foo-bar/`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://日本語.com" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://日本語.com/" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://日本語.com/ほげ" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92`,
-          );
-          expect(createExpectCTHeaderValue([true, { reportURI: "https://日本語.com/ほげ/" }])).toBe(
-            `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/`,
-          );
-        });
-      });
-
-      context("the option is invalid URI", () => {
-        it("should raise error", () => {
-          expect(() => createExpectCTHeaderValue([true, { reportURI: "example.com" }])).toThrow();
-          expect(() => createExpectCTHeaderValue([true, { reportURI: "foo-bar" }])).toThrow();
-          expect(() => createExpectCTHeaderValue([true, { reportURI: "ふがほげ" }])).toThrow();
-        });
-      });
+    let strictURIEncoderSpy: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
+    beforeAll(() => {
+      strictURIEncoderSpy = jest.fn(encodeStrictURI);
     });
 
-    context("the option is URL object", () => {
-      it("should convert to string and return", () => {
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://example.com") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://example.com/`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://example.com/") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://example.com/`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://example.com/foo-bar") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://example.com/foo-bar`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://example.com/foo-bar/") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://example.com/foo-bar/`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://日本語.com") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://日本語.com/") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://日本語.com/ほげ") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92`,
-        );
-        expect(createExpectCTHeaderValue([true, { reportURI: new URL("https://日本語.com/ほげ/") }])).toBe(
-          `max-age=${secondsOfOneDay}, report-uri=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/`,
-        );
-      });
+    it('should call "encodeStrictURI"', () => {
+      const uri = "https://example.com/";
+      createExpectCTHeaderValue([true, { reportURI: uri }], strictURIEncoderSpy);
+
+      expect(strictURIEncoderSpy).toBeCalledTimes(1);
+      expect(strictURIEncoderSpy).toBeCalledWith(uri);
+    });
+
+    it('should return "max-age" and the URI"', () => {
+      const uri = "https://example.com/";
+      expect(createExpectCTHeaderValue([true, { reportURI: uri }])).toBe(`max-age=${secondsOfOneDay}, report-uri=${uri}`);
     });
   });
 

--- a/src/rules/expect-ct.spec.ts
+++ b/src/rules/expect-ct.spec.ts
@@ -2,24 +2,25 @@ import { encodeStrictURI } from "./shared";
 import { createExpectCTHeader, createExpectCTHeaderValue } from "./expect-ct";
 
 describe("createExpectCTHeader", () => {
-  let headerValueCreatorSpy: jest.Mock<
+  let headerValueCreatorMock: jest.Mock<
     ReturnType<typeof createExpectCTHeaderValue>,
     Parameters<typeof createExpectCTHeaderValue>
   >;
   beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createExpectCTHeaderValue);
+    headerValueCreatorMock = jest.fn(createExpectCTHeaderValue);
   });
 
   it('should return "Expect-CT" as object\'s "name" property', () => {
-    expect(createExpectCTHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "Expect-CT");
+    expect(createExpectCTHeader(undefined, headerValueCreatorMock)).toHaveProperty("name", "Expect-CT");
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+    const dummyOption: Parameters<typeof createExpectCTHeader>[0] = undefined;
     const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    headerValueCreatorMock.mockReturnValue(dummyValue);
 
-    expect(createExpectCTHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    expect(createExpectCTHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+    expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
   });
 });
 
@@ -90,17 +91,16 @@ describe("createExpectCTHeaderValue", () => {
   });
 
   context('when specifying "reportURI" option', () => {
-    let strictURIEncoderSpy: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
+    let strictURIEncoderMock: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
     beforeAll(() => {
-      strictURIEncoderSpy = jest.fn(encodeStrictURI);
+      strictURIEncoderMock = jest.fn(encodeStrictURI);
     });
 
-    it('should call "encodeStrictURI"', () => {
+    it("should call the second argument", () => {
       const uri = "https://example.com/";
-      createExpectCTHeaderValue([true, { reportURI: uri }], strictURIEncoderSpy);
+      createExpectCTHeaderValue([true, { reportURI: uri }], strictURIEncoderMock);
 
-      expect(strictURIEncoderSpy).toBeCalledTimes(1);
-      expect(strictURIEncoderSpy).toBeCalledWith(uri);
+      expect(strictURIEncoderMock).toBeCalledWith(uri);
     });
 
     it('should return "max-age" and the URI"', () => {

--- a/src/rules/expect-ct.ts
+++ b/src/rules/expect-ct.ts
@@ -1,11 +1,12 @@
 import { ResponseHeader } from "../shared";
+import { encodeStrictURI } from "./shared";
 
 export type ExpectCTOption = boolean | [true, Partial<{ maxAge: number; enforce: boolean; reportURI: string | URL }>];
 
 const headerName = "Expect-CT";
 const defaultMaxAge = 60 * 60 * 24; // 1 day
 
-export const createExpectCTHeaderValue = (option?: ExpectCTOption): string | undefined => {
+export const createExpectCTHeaderValue = (option?: ExpectCTOption, strictURIEncoder = encodeStrictURI): string | undefined => {
   if (option == undefined) return;
   if (option === false) return;
   if (option === true) return `max-age=${defaultMaxAge}`;
@@ -22,7 +23,7 @@ export const createExpectCTHeaderValue = (option?: ExpectCTOption): string | und
     return [
       `max-age=${maxAge}`,
       enforce ? "enforce" : undefined,
-      reportURI != undefined ? `report-uri=${new URL(reportURI.toString())}` : undefined,
+      reportURI != undefined ? `report-uri=${strictURIEncoder(reportURI)}` : undefined,
     ]
       .filter((value) => value != undefined)
       .join(", ");

--- a/src/rules/force-https-redirect.spec.ts
+++ b/src/rules/force-https-redirect.spec.ts
@@ -1,24 +1,25 @@
 import { createForceHTTPSRedirectHeader, createHSTSHeaderValue } from "./force-https-redirect";
 
 describe("createForceHTTPSRedirectHeader", () => {
-  let headerValueCreatorSpy: jest.Mock<ReturnType<typeof createHSTSHeaderValue>, Parameters<typeof createHSTSHeaderValue>>;
+  let headerValueCreatorMock: jest.Mock<ReturnType<typeof createHSTSHeaderValue>, Parameters<typeof createHSTSHeaderValue>>;
   beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createHSTSHeaderValue);
+    headerValueCreatorMock = jest.fn(createHSTSHeaderValue);
   });
 
   it('should return "Strict-Transport-Security" as object\'s "name" property', () => {
-    expect(createForceHTTPSRedirectHeader(undefined, headerValueCreatorSpy)).toHaveProperty(
+    expect(createForceHTTPSRedirectHeader(undefined, headerValueCreatorMock)).toHaveProperty(
       "name",
       "Strict-Transport-Security",
     );
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+    const dummyOption: Parameters<typeof createForceHTTPSRedirectHeader>[0] = undefined;
     const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    headerValueCreatorMock.mockReturnValue(dummyValue);
 
-    expect(createForceHTTPSRedirectHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    expect(createForceHTTPSRedirectHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+    expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
   });
 });
 

--- a/src/rules/frame-guard.spec.ts
+++ b/src/rules/frame-guard.spec.ts
@@ -2,24 +2,25 @@ import { encodeStrictURI } from "./shared";
 import { createFrameGuardHeader, createXFrameOptionsHeaderValue } from "./frame-guard";
 
 describe("createFrameGuardHeader", () => {
-  let headerValueCreatorSpy: jest.Mock<
+  let headerValueCreatorMock: jest.Mock<
     ReturnType<typeof createXFrameOptionsHeaderValue>,
     Parameters<typeof createXFrameOptionsHeaderValue>
   >;
   beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createXFrameOptionsHeaderValue);
+    headerValueCreatorMock = jest.fn(createXFrameOptionsHeaderValue);
   });
 
   it('should return "X-Frame-Options" as object\'s "name" property', () => {
-    expect(createFrameGuardHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "X-Frame-Options");
+    expect(createFrameGuardHeader(undefined, headerValueCreatorMock)).toHaveProperty("name", "X-Frame-Options");
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+    const dummyOption: Parameters<typeof createFrameGuardHeader>[0] = undefined;
     const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    headerValueCreatorMock.mockReturnValue(dummyValue);
 
-    expect(createFrameGuardHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    expect(createFrameGuardHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+    expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
   });
 });
 
@@ -50,17 +51,16 @@ describe("createXFrameOptionsHeaderValue", () => {
   });
 
   context('when giving "allow-from" as array', () => {
-    let strictURIEncoderSpy: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
+    let strictURIEncoderMock: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
     beforeAll(() => {
-      strictURIEncoderSpy = jest.fn(encodeStrictURI);
+      strictURIEncoderMock = jest.fn(encodeStrictURI);
     });
 
     it('should call "encodeStrictURI"', () => {
       const uri = "https://example.com/";
-      createXFrameOptionsHeaderValue(["allow-from", { uri }], strictURIEncoderSpy);
+      createXFrameOptionsHeaderValue(["allow-from", { uri }], strictURIEncoderMock);
 
-      expect(strictURIEncoderSpy).toBeCalledTimes(1);
-      expect(strictURIEncoderSpy).toBeCalledWith(uri);
+      expect(strictURIEncoderMock).toBeCalledWith(uri);
     });
 
     it('should return "allow-from" and the URI', () => {

--- a/src/rules/frame-guard.spec.ts
+++ b/src/rules/frame-guard.spec.ts
@@ -1,3 +1,4 @@
+import { encodeStrictURI } from "./shared";
 import { createFrameGuardHeader, createXFrameOptionsHeaderValue } from "./frame-guard";
 
 describe("createFrameGuardHeader", () => {
@@ -49,72 +50,22 @@ describe("createXFrameOptionsHeaderValue", () => {
   });
 
   context('when giving "allow-from" as array', () => {
-    context('"uri" option is string', () => {
-      context('"uri" option is valid URI', () => {
-        it('should return "allow-from" string and escaped URI', () => {
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://example.com" }])).toBe(
-            "allow-from https://example.com/",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://example.com/" }])).toBe(
-            "allow-from https://example.com/",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://example.com/foo-bar" }])).toBe(
-            "allow-from https://example.com/foo-bar",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://example.com/foo-bar/" }])).toBe(
-            "allow-from https://example.com/foo-bar/",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://日本語.com" }])).toBe(
-            "allow-from https://xn--wgv71a119e.com/",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://日本語.com/" }])).toBe(
-            "allow-from https://xn--wgv71a119e.com/",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://日本語.com/ほげ" }])).toBe(
-            "allow-from https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92",
-          );
-          expect(createXFrameOptionsHeaderValue(["allow-from", { uri: "https://日本語.com/ほげ/" }])).toBe(
-            "allow-from https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/",
-          );
-        });
-      });
-
-      context('"uri" option is invalid URI', () => {
-        it("should raise error", () => {
-          expect(() => createXFrameOptionsHeaderValue(["allow-from", { uri: "example.com" }])).toThrow();
-          expect(() => createXFrameOptionsHeaderValue(["allow-from", { uri: "foo-bar" }])).toThrow();
-          expect(() => createXFrameOptionsHeaderValue(["allow-from", { uri: "ふがほげ" }])).toThrow();
-        });
-      });
+    let strictURIEncoderSpy: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
+    beforeAll(() => {
+      strictURIEncoderSpy = jest.fn(encodeStrictURI);
     });
 
-    context('"uri" option is URL object', () => {
-      it("should convert to string and return", () => {
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://example.com") }])).toBe(
-          "allow-from https://example.com/",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://example.com/") }])).toBe(
-          "allow-from https://example.com/",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://example.com/foo-bar") }])).toBe(
-          "allow-from https://example.com/foo-bar",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://example.com/foo-bar/") }])).toBe(
-          "allow-from https://example.com/foo-bar/",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://日本語.com") }])).toBe(
-          "allow-from https://xn--wgv71a119e.com/",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://日本語.com/") }])).toBe(
-          "allow-from https://xn--wgv71a119e.com/",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://日本語.com/ほげ") }])).toBe(
-          "allow-from https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92",
-        );
-        expect(createXFrameOptionsHeaderValue(["allow-from", { uri: new URL("https://日本語.com/ほげ/") }])).toBe(
-          "allow-from https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/",
-        );
-      });
+    it('should call "encodeStrictURI"', () => {
+      const uri = "https://example.com/";
+      createXFrameOptionsHeaderValue(["allow-from", { uri }], strictURIEncoderSpy);
+
+      expect(strictURIEncoderSpy).toBeCalledTimes(1);
+      expect(strictURIEncoderSpy).toBeCalledWith(uri);
+    });
+
+    it('should return "allow-from" and the URI', () => {
+      const uri = "https://example.com/";
+      expect(createXFrameOptionsHeaderValue(["allow-from", { uri }])).toBe(`allow-from ${uri}`);
     });
   });
 

--- a/src/rules/frame-guard.ts
+++ b/src/rules/frame-guard.ts
@@ -1,17 +1,21 @@
 import { ResponseHeader } from "../shared";
+import { encodeStrictURI } from "./shared";
 
 export type FrameGuardOption = false | "deny" | "sameorigin" | ["allow-from", { uri: string | URL }];
 
 const headerName = "X-Frame-Options";
 
-export const createXFrameOptionsHeaderValue = (option?: FrameGuardOption): string | undefined => {
+export const createXFrameOptionsHeaderValue = (
+  option?: FrameGuardOption,
+  strictURIEncoder = encodeStrictURI,
+): string | undefined => {
   if (option == undefined) return "deny";
   if (option === false) return;
   if (option === "deny") return option;
   if (option === "sameorigin") return option;
 
   if (Array.isArray(option)) {
-    if (option[0] === "allow-from") return `${option[0]} ${new URL(option[1].uri.toString())}`;
+    if (option[0] === "allow-from") return `${option[0]} ${strictURIEncoder(option[1].uri)}`;
   }
 
   throw new Error(`Invalid value for ${headerName}: ${option}`);

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -3,5 +3,5 @@ export { ForceHTTPSRedirectOption, createForceHTTPSRedirectHeader } from "./forc
 export { FrameGuardOption, createFrameGuardHeader } from "./frame-guard";
 export { NoopenOption, createNoopenHeader } from "./noopen";
 export { NosniffOption, createNosniffHeader } from "./nosniff";
-export { ReferrerGuardOption, createReferrerGuardHeader } from "./referrer-guard";
+export { ReferrerPolicyOption, createReferrerPolicyHeader } from "./referrer-policy";
 export { XSSProtectionOption, createXSSProtectionHeader } from "./xss-protection";

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,3 +1,4 @@
+export { ContentSecurityPolicyOption, createContentSecurityPolicyHeader } from "./content-security-policy";
 export { ExpectCTOption, createExpectCTHeader } from "./expect-ct";
 export { ForceHTTPSRedirectOption, createForceHTTPSRedirectHeader } from "./force-https-redirect";
 export { FrameGuardOption, createFrameGuardHeader } from "./frame-guard";

--- a/src/rules/noopen.spec.ts
+++ b/src/rules/noopen.spec.ts
@@ -1,24 +1,25 @@
 import { createNoopenHeader, createXDownloadOptionsHeaderValue } from "./noopen";
 
 describe("createNoopenHeader", () => {
-  let headerValueCreatorSpy: jest.Mock<
+  let headerValueCreatorMock: jest.Mock<
     ReturnType<typeof createXDownloadOptionsHeaderValue>,
     Parameters<typeof createXDownloadOptionsHeaderValue>
   >;
   beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createXDownloadOptionsHeaderValue);
+    headerValueCreatorMock = jest.fn(createXDownloadOptionsHeaderValue);
   });
 
   it('should return "X-Download-Options" as object\'s "name" property', () => {
-    expect(createNoopenHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "X-Download-Options");
+    expect(createNoopenHeader(undefined, headerValueCreatorMock)).toHaveProperty("name", "X-Download-Options");
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+    const dummyOption: Parameters<typeof createNoopenHeader>[0] = undefined;
     const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    headerValueCreatorMock.mockReturnValue(dummyValue);
 
-    expect(createNoopenHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    expect(createNoopenHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+    expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
   });
 });
 

--- a/src/rules/nosniff.spec.ts
+++ b/src/rules/nosniff.spec.ts
@@ -1,24 +1,25 @@
 import { createNosniffHeader, createXContentTypeOptionsHeaderValue } from "./nosniff";
 
 describe("createNosniffHeader", () => {
-  let headerValueCreatorSpy: jest.Mock<
+  let headerValueCreatorMock: jest.Mock<
     ReturnType<typeof createXContentTypeOptionsHeaderValue>,
     Parameters<typeof createXContentTypeOptionsHeaderValue>
   >;
   beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createXContentTypeOptionsHeaderValue);
+    headerValueCreatorMock = jest.fn(createXContentTypeOptionsHeaderValue);
   });
 
   it('should return "X-Content-Type-Options" as object\'s "name" property', () => {
-    expect(createNosniffHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "X-Content-Type-Options");
+    expect(createNosniffHeader(undefined, headerValueCreatorMock)).toHaveProperty("name", "X-Content-Type-Options");
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+    const dummyOption: Parameters<typeof createNosniffHeader>[0] = undefined;
     const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    headerValueCreatorMock.mockReturnValue(dummyValue);
 
-    expect(createNosniffHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    expect(createNosniffHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+    expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
   });
 });
 

--- a/src/rules/referrer-policy.spec.ts
+++ b/src/rules/referrer-policy.spec.ts
@@ -1,28 +1,36 @@
 import { createReferrerPolicyHeader, createReferrerPolicyHeaderValue } from "./referrer-policy";
 
-describe("headerValueCreator", () => {
-  let headerValueCreatorSpy: jest.Mock<
-    ReturnType<typeof createReferrerPolicyHeaderValue>,
-    Parameters<typeof createReferrerPolicyHeaderValue>
-  >;
-  beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createReferrerPolicyHeaderValue);
+describe("createReferrerPolicyHeader", () => {
+  context("when giving undefined", () => {
+    it("should return undefined", () => {
+      expect(createReferrerPolicyHeader()).toBeUndefined();
+    });
   });
 
-  it('should return "Referrer-Policy" as object\'s "name" property', () => {
-    expect(createReferrerPolicyHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "Referrer-Policy");
-  });
+  context("when giving not undefined", () => {
+    let headerValueCreatorSpy: jest.Mock<
+      ReturnType<typeof createReferrerPolicyHeaderValue>,
+      Parameters<typeof createReferrerPolicyHeaderValue>
+    >;
+    beforeAll(() => {
+      headerValueCreatorSpy = jest.fn(createReferrerPolicyHeaderValue);
+    });
 
-  it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
-    const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    it('should return "Referrer-Policy" as object\'s "name" property', () => {
+      expect(createReferrerPolicyHeader("no-referrer", headerValueCreatorSpy)).toHaveProperty("name", "Referrer-Policy");
+    });
 
-    expect(createReferrerPolicyHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+      const dummyValue = "dummy-value";
+      headerValueCreatorSpy.mockReturnValue(dummyValue);
+
+      expect(createReferrerPolicyHeader("no-referrer", headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
+      expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    });
   });
 });
 
-describe("createSurrogateControlHeaderValue", () => {
+describe("createReferrerPolicyHeaderValue", () => {
   context("when giving undefined", () => {
     it("should return undefined", () => {
       expect(createReferrerPolicyHeaderValue()).toBeUndefined();

--- a/src/rules/referrer-policy.spec.ts
+++ b/src/rules/referrer-policy.spec.ts
@@ -1,4 +1,4 @@
-import { createReferrerGuardHeader, createReferrerPolicyHeaderValue } from "./referrer-guard";
+import { createReferrerPolicyHeader, createReferrerPolicyHeaderValue } from "./referrer-policy";
 
 describe("headerValueCreator", () => {
   let headerValueCreatorSpy: jest.Mock<
@@ -10,14 +10,14 @@ describe("headerValueCreator", () => {
   });
 
   it('should return "Referrer-Policy" as object\'s "name" property', () => {
-    expect(createReferrerGuardHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "Referrer-Policy");
+    expect(createReferrerPolicyHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "Referrer-Policy");
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
     const dummyValue = "dummy-value";
     headerValueCreatorSpy.mockReturnValue(dummyValue);
 
-    expect(createReferrerGuardHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
+    expect(createReferrerPolicyHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
     expect(headerValueCreatorSpy).toBeCalledTimes(1);
   });
 });

--- a/src/rules/referrer-policy.spec.ts
+++ b/src/rules/referrer-policy.spec.ts
@@ -8,24 +8,25 @@ describe("createReferrerPolicyHeader", () => {
   });
 
   context("when giving not undefined", () => {
-    let headerValueCreatorSpy: jest.Mock<
+    let headerValueCreatorMock: jest.Mock<
       ReturnType<typeof createReferrerPolicyHeaderValue>,
       Parameters<typeof createReferrerPolicyHeaderValue>
     >;
     beforeAll(() => {
-      headerValueCreatorSpy = jest.fn(createReferrerPolicyHeaderValue);
+      headerValueCreatorMock = jest.fn(createReferrerPolicyHeaderValue);
     });
 
     it('should return "Referrer-Policy" as object\'s "name" property', () => {
-      expect(createReferrerPolicyHeader("no-referrer", headerValueCreatorSpy)).toHaveProperty("name", "Referrer-Policy");
+      expect(createReferrerPolicyHeader("no-referrer", headerValueCreatorMock)).toHaveProperty("name", "Referrer-Policy");
     });
 
     it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+      const dummyOption: Parameters<typeof createReferrerPolicyHeader>[0] = "no-referrer";
       const dummyValue = "dummy-value";
-      headerValueCreatorSpy.mockReturnValue(dummyValue);
+      headerValueCreatorMock.mockReturnValue(dummyValue);
 
-      expect(createReferrerPolicyHeader("no-referrer", headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-      expect(headerValueCreatorSpy).toBeCalledTimes(1);
+      expect(createReferrerPolicyHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+      expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
     });
   });
 });

--- a/src/rules/referrer-policy.ts
+++ b/src/rules/referrer-policy.ts
@@ -1,4 +1,5 @@
 import { ResponseHeader } from "../shared";
+import { wrapArray } from "./shared";
 
 const supportedValues = [
   "no-referrer",
@@ -18,8 +19,7 @@ export const createReferrerPolicyHeaderValue = (option?: ReferrerPolicyOption): 
   if (option == undefined) return;
   if (option === false) return;
 
-  const values = Array.isArray(option) ? option : [option];
-
+  const values = wrapArray(option);
   values.forEach((value) => {
     if ((value as string) === "unsafe-url") throw new Error(`Cannot specify a dangerous value for ${headerName}: ${value}`);
     if (!supportedValues.includes(value)) throw new Error(`Invalid value for ${headerName}: ${value}`);

--- a/src/rules/referrer-policy.ts
+++ b/src/rules/referrer-policy.ts
@@ -31,7 +31,9 @@ export const createReferrerPolicyHeaderValue = (option?: ReferrerPolicyOption): 
 export const createReferrerPolicyHeader = (
   option?: ReferrerPolicyOption,
   headerValueCreator = createReferrerPolicyHeaderValue,
-): ResponseHeader => {
+): ResponseHeader | undefined => {
+  if (option == undefined) return;
+
   const value = headerValueCreator(option);
 
   return { name: headerName, value };

--- a/src/rules/referrer-policy.ts
+++ b/src/rules/referrer-policy.ts
@@ -10,11 +10,11 @@ const supportedValues = [
   "strict-origin-when-cross-origin",
 ] as const;
 type SupportedValue = typeof supportedValues[number];
-export type ReferrerGuardOption = false | SupportedValue | SupportedValue[];
+export type ReferrerPolicyOption = false | SupportedValue | SupportedValue[];
 
 const headerName = "Referrer-Policy";
 
-export const createReferrerPolicyHeaderValue = (option?: ReferrerGuardOption): string | undefined => {
+export const createReferrerPolicyHeaderValue = (option?: ReferrerPolicyOption): string | undefined => {
   if (option == undefined) return;
   if (option === false) return;
 
@@ -28,8 +28,8 @@ export const createReferrerPolicyHeaderValue = (option?: ReferrerGuardOption): s
   return values.join(", ");
 };
 
-export const createReferrerGuardHeader = (
-  option?: ReferrerGuardOption,
+export const createReferrerPolicyHeader = (
+  option?: ReferrerPolicyOption,
   headerValueCreator = createReferrerPolicyHeaderValue,
 ): ResponseHeader => {
   const value = headerValueCreator(option);

--- a/src/rules/shared/array-wrapper.spec.ts
+++ b/src/rules/shared/array-wrapper.spec.ts
@@ -1,0 +1,17 @@
+import { wrapArray } from "./array-wrapper";
+
+describe("wrapArray", () => {
+  context("when giving a value not array", () => {
+    it("should wrap the value as array", () => {
+      const value = 123;
+      expect(wrapArray(value)).toEqual([value]);
+    });
+  });
+
+  context("when giving an array", () => {
+    it("should return the value", () => {
+      const value = [123];
+      expect(wrapArray(value)).toEqual(value);
+    });
+  });
+});

--- a/src/rules/shared/array-wrapper.ts
+++ b/src/rules/shared/array-wrapper.ts
@@ -1,0 +1,1 @@
+export const wrapArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [value]);

--- a/src/rules/shared/index.ts
+++ b/src/rules/shared/index.ts
@@ -1,0 +1,1 @@
+export { wrapArray } from "./array-wrapper";

--- a/src/rules/shared/index.ts
+++ b/src/rules/shared/index.ts
@@ -1,1 +1,2 @@
 export { wrapArray } from "./array-wrapper";
+export { encodeStrictURI } from "./uri-encoder";

--- a/src/rules/shared/uri-encoder.spec.ts
+++ b/src/rules/shared/uri-encoder.spec.ts
@@ -1,0 +1,37 @@
+import { encodeStrictURI } from "./uri-encoder";
+
+describe("encodeStrictURI", () => {
+  context("when giving string", () => {
+    it("should encode and return", () => {
+      expect(encodeStrictURI("https://example.com")).toBe("https://example.com/");
+      expect(encodeStrictURI("https://example.com/")).toBe("https://example.com/");
+      expect(encodeStrictURI("https://example.com/foo-bar")).toBe("https://example.com/foo-bar");
+      expect(encodeStrictURI("https://example.com/foo-bar/")).toBe("https://example.com/foo-bar/");
+      expect(encodeStrictURI("https://日本語.com")).toBe("https://xn--wgv71a119e.com/");
+      expect(encodeStrictURI("https://日本語.com/")).toBe("https://xn--wgv71a119e.com/");
+      expect(encodeStrictURI("https://日本語.com/ほげ")).toBe("https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92");
+      expect(encodeStrictURI("https://日本語.com/ほげ/")).toBe("https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/");
+    });
+  });
+
+  context("when giving URL object", () => {
+    it("should convert to string", () => {
+      expect(encodeStrictURI(new URL("https://example.com"))).toBe("https://example.com/");
+      expect(encodeStrictURI(new URL("https://example.com/"))).toBe("https://example.com/");
+      expect(encodeStrictURI(new URL("https://example.com/foo-bar"))).toBe("https://example.com/foo-bar");
+      expect(encodeStrictURI(new URL("https://example.com/foo-bar/"))).toBe("https://example.com/foo-bar/");
+      expect(encodeStrictURI(new URL("https://日本語.com"))).toBe("https://xn--wgv71a119e.com/");
+      expect(encodeStrictURI(new URL("https://日本語.com/"))).toBe("https://xn--wgv71a119e.com/");
+      expect(encodeStrictURI(new URL("https://日本語.com/ほげ"))).toBe("https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92");
+      expect(encodeStrictURI(new URL("https://日本語.com/ほげ/"))).toBe("https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/");
+    });
+  });
+
+  context("when giving invalid URI", () => {
+    it("should raise error", () => {
+      expect(() => encodeStrictURI("example.com")).toThrow();
+      expect(() => encodeStrictURI("foo-bar")).toThrow();
+      expect(() => encodeStrictURI("ふがほげ")).toThrow();
+    });
+  });
+});

--- a/src/rules/shared/uri-encoder.ts
+++ b/src/rules/shared/uri-encoder.ts
@@ -1,0 +1,1 @@
+export const encodeStrictURI = (uri: string | URL) => new URL(uri.toString()).toString();

--- a/src/rules/xss-protection.spec.ts
+++ b/src/rules/xss-protection.spec.ts
@@ -2,24 +2,25 @@ import { encodeStrictURI } from "./shared";
 import { createXSSProtectionHeader, createXXSSProtectionHeaderValue } from "./xss-protection";
 
 describe("createXSSProtectionHeader", () => {
-  let headerValueCreatorSpy: jest.Mock<
+  let headerValueCreatorMock: jest.Mock<
     ReturnType<typeof createXXSSProtectionHeaderValue>,
     Parameters<typeof createXXSSProtectionHeaderValue>
   >;
   beforeAll(() => {
-    headerValueCreatorSpy = jest.fn(createXXSSProtectionHeaderValue);
+    headerValueCreatorMock = jest.fn(createXXSSProtectionHeaderValue);
   });
 
   it('should return "X-XSS-Protection" as object\'s "name" property', () => {
-    expect(createXSSProtectionHeader(undefined, headerValueCreatorSpy)).toHaveProperty("name", "X-XSS-Protection");
+    expect(createXSSProtectionHeader(undefined, headerValueCreatorMock)).toHaveProperty("name", "X-XSS-Protection");
   });
 
   it('should call the second argument function and return a value from the function as object\'s "value" property', () => {
+    const dummyOption: Parameters<typeof createXSSProtectionHeader>[0] = undefined;
     const dummyValue = "dummy-value";
-    headerValueCreatorSpy.mockReturnValue(dummyValue);
+    headerValueCreatorMock.mockReturnValue(dummyValue);
 
-    expect(createXSSProtectionHeader(undefined, headerValueCreatorSpy)).toHaveProperty("value", dummyValue);
-    expect(headerValueCreatorSpy).toBeCalledTimes(1);
+    expect(createXSSProtectionHeader(dummyOption, headerValueCreatorMock)).toHaveProperty("value", dummyValue);
+    expect(headerValueCreatorMock).toBeCalledWith(dummyOption);
   });
 });
 
@@ -50,17 +51,16 @@ describe("createXXSSProtectionHeaderValue", () => {
   });
 
   context('when giving "report" as array', () => {
-    let strictURIEncoderSpy: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
+    let strictURIEncoderMock: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
     beforeAll(() => {
-      strictURIEncoderSpy = jest.fn(encodeStrictURI);
+      strictURIEncoderMock = jest.fn(encodeStrictURI);
     });
 
-    it('should call "encodeStrictURI"', () => {
+    it("should call the second argument", () => {
       const uri = "https://example.com/";
-      createXXSSProtectionHeaderValue(["report", { uri }], strictURIEncoderSpy);
+      createXXSSProtectionHeaderValue(["report", { uri }], strictURIEncoderMock);
 
-      expect(strictURIEncoderSpy).toBeCalledTimes(1);
-      expect(strictURIEncoderSpy).toBeCalledWith(uri);
+      expect(strictURIEncoderMock).toBeCalledWith(uri);
     });
 
     it('should return "1; report=" and the URI', () => {

--- a/src/rules/xss-protection.spec.ts
+++ b/src/rules/xss-protection.spec.ts
@@ -1,3 +1,4 @@
+import { encodeStrictURI } from "./shared";
 import { createXSSProtectionHeader, createXXSSProtectionHeaderValue } from "./xss-protection";
 
 describe("createXSSProtectionHeader", () => {
@@ -49,72 +50,22 @@ describe("createXXSSProtectionHeaderValue", () => {
   });
 
   context('when giving "report" as array', () => {
-    context('"uri" option is string', () => {
-      context('"uri" option is valid URI', () => {
-        it('should return "1; report=" string and escaped URI', () => {
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://example.com" }])).toBe(
-            "1; report=https://example.com/",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://example.com/" }])).toBe(
-            "1; report=https://example.com/",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://example.com/foo-bar" }])).toBe(
-            "1; report=https://example.com/foo-bar",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://example.com/foo-bar/" }])).toBe(
-            "1; report=https://example.com/foo-bar/",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://日本語.com" }])).toBe(
-            "1; report=https://xn--wgv71a119e.com/",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://日本語.com/" }])).toBe(
-            "1; report=https://xn--wgv71a119e.com/",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://日本語.com/ほげ" }])).toBe(
-            "1; report=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92",
-          );
-          expect(createXXSSProtectionHeaderValue(["report", { uri: "https://日本語.com/ほげ/" }])).toBe(
-            "1; report=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/",
-          );
-        });
-      });
-
-      context('"uri" option is invalid URI', () => {
-        it("should raise error", () => {
-          expect(() => createXXSSProtectionHeaderValue(["report", { uri: "example.com" }])).toThrow();
-          expect(() => createXXSSProtectionHeaderValue(["report", { uri: "foo-bar" }])).toThrow();
-          expect(() => createXXSSProtectionHeaderValue(["report", { uri: "ふがほげ" }])).toThrow();
-        });
-      });
+    let strictURIEncoderSpy: jest.Mock<ReturnType<typeof encodeStrictURI>, Parameters<typeof encodeStrictURI>>;
+    beforeAll(() => {
+      strictURIEncoderSpy = jest.fn(encodeStrictURI);
     });
 
-    context('"uri" option is URL object', () => {
-      it("should convert to string and return", () => {
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://example.com") }])).toBe(
-          "1; report=https://example.com/",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://example.com/") }])).toBe(
-          "1; report=https://example.com/",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://example.com/foo-bar") }])).toBe(
-          "1; report=https://example.com/foo-bar",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://example.com/foo-bar/") }])).toBe(
-          "1; report=https://example.com/foo-bar/",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://日本語.com") }])).toBe(
-          "1; report=https://xn--wgv71a119e.com/",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://日本語.com/") }])).toBe(
-          "1; report=https://xn--wgv71a119e.com/",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://日本語.com/ほげ") }])).toBe(
-          "1; report=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92",
-        );
-        expect(createXXSSProtectionHeaderValue(["report", { uri: new URL("https://日本語.com/ほげ/") }])).toBe(
-          "1; report=https://xn--wgv71a119e.com/%E3%81%BB%E3%81%92/",
-        );
-      });
+    it('should call "encodeStrictURI"', () => {
+      const uri = "https://example.com/";
+      createXXSSProtectionHeaderValue(["report", { uri }], strictURIEncoderSpy);
+
+      expect(strictURIEncoderSpy).toBeCalledTimes(1);
+      expect(strictURIEncoderSpy).toBeCalledWith(uri);
+    });
+
+    it('should return "1; report=" and the URI', () => {
+      const uri = "https://example.com/";
+      expect(createXXSSProtectionHeaderValue(["report", { uri }])).toBe(`1; report=${uri}`);
     });
   });
 

--- a/src/rules/xss-protection.ts
+++ b/src/rules/xss-protection.ts
@@ -1,17 +1,21 @@
 import { ResponseHeader } from "../shared";
+import { encodeStrictURI } from "./shared";
 
 export type XSSProtectionOption = false | "sanitize" | "block-rendering" | ["report", { uri: string | URL }];
 
 const headerName = "X-XSS-Protection";
 
-export const createXXSSProtectionHeaderValue = (option?: XSSProtectionOption): string | undefined => {
+export const createXXSSProtectionHeaderValue = (
+  option?: XSSProtectionOption,
+  strictURIEncoder = encodeStrictURI,
+): string | undefined => {
   if (option == undefined) return "1";
   if (option === false) return "0";
   if (option === "sanitize") return "1";
   if (option === "block-rendering") return "1; mode=block";
 
   if (Array.isArray(option)) {
-    if (option[0] === "report") return `1; report=${new URL(option[1].uri.toString())}`;
+    if (option[0] === "report") return `1; report=${strictURIEncoder(option[1].uri)}`;
   }
 
   throw new Error(`Invalid value for ${headerName}: ${option}`);


### PR DESCRIPTION
# New Features
- Add `wrapArray` function as shared functions
- Add `encodeStrictURI` function as shared function
- Add a rule for Content Security Policy


# Changes and Fixes
- Rename referrerGuard to referrerPolicy
- Make `createReferrerPolicyHeader` to return nullable value


# Refactors
- Refactor tests
