### PR TITLE
Fix setting headers after sending

### DIFF
--- a/example/pages/redirector.tsx
+++ b/example/pages/redirector.tsx
@@ -1,0 +1,19 @@
+import { ServerResponse } from "http";
+import { NextPage } from "next";
+
+const moveToTop = (res: ServerResponse) => {
+  res.writeHead(302, { Location: "/" });
+  res.end();
+};
+
+const Page: NextPage = () => null;
+
+Page.getInitialProps = async ({ res }) => {
+  if (res == undefined) return {};
+
+  moveToTop(res);
+
+  return {};
+};
+
+export default Page;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import * as rules from "./rules";
-import { default as withSecureHeaders, createHeadersObject } from "./index";
+import { createHeadersObject, default as withSecureHeaders } from "./index";
 
 describe("createHeadersObject", () => {
   let contentSecurityPolicyHeaderCreatorSpy: jest.SpyInstance<
@@ -185,6 +185,29 @@ describe("withSecureHeaders", () => {
         const ComponentWithSecureHeaders = withSecureHeaders()(DummyComponent);
 
         const dummyContext: any = { ctx: { res: { setHeader: jest.fn() } } };
+        await expect(ComponentWithSecureHeaders.getInitialProps!(dummyContext)).resolves.toEqual(dummyInitialProps);
+      });
+    });
+
+    context('when "headersSent" property of "res" is true', () => {
+      it('should not call "context.ctx.res.setHeader()"', async () => {
+        const DummyComponent = () => React.createElement("div");
+        const ComponentWithSecureHeaders = withSecureHeaders()(DummyComponent);
+
+        const resSetHeeaderSpy = jest.fn();
+        const dummyContext: any = { ctx: { res: { setHeader: resSetHeeaderSpy, headersSent: true } } };
+        await ComponentWithSecureHeaders.getInitialProps!(dummyContext);
+
+        expect(resSetHeeaderSpy).not.toBeCalled();
+      });
+
+      it('should return the returned value from "getInitialProps"', async () => {
+        const DummyComponent = () => React.createElement("div");
+        const dummyInitialProps = { dummy: "dummy" };
+        DummyComponent.getInitialProps = async () => dummyInitialProps;
+        const ComponentWithSecureHeaders = withSecureHeaders()(DummyComponent);
+
+        const dummyContext: any = { ctx: { res: { setHeader: jest.fn(), headersSent: true } } };
         await expect(ComponentWithSecureHeaders.getInitialProps!(dummyContext)).resolves.toEqual(dummyInitialProps);
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export default (options: Options = {}) => (ChildComponent: NextComponent) => {
     const initialProps = (await ChildComponent.getInitialProps?.(context)) ?? {};
     const res = context.res ?? context.ctx?.res;
     if (res == undefined) return initialProps;
+    if (res.headersSent) return initialProps;
 
     const headers = createHeadersObject(options);
     Object.entries(headers).forEach(([name, value]) => res.setHeader(name, value));


### PR DESCRIPTION
# New Features
- Add a sample page which redirects to a specific page


# Changes and Fixes
- Fix `Cannot set headers after they are sent to the client` error
