### PR TITLE
Fix missing deps on react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "next-secure-headers",
       "version": "2.2.0",
       "license": "MIT",
+      "dependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      },
       "devDependencies": {
         "@types/jest": "^26.0.20",
         "@types/jest-plugin-context": "^2.9.4",
@@ -28,6 +32,14 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "^14.14.31 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -747,7 +759,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -4378,7 +4389,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "clean": "rm -rf ./lib ./coverage"
   },
   "config": {},
-  "dependencies": {},
+  "dependencies": {
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/jest-plugin-context": "^2.9.4",
@@ -57,7 +59,14 @@
     "ts-jest": "^26.5.2",
     "typescript": "^4.1.3"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "@types/node": "^14.14.31 || ^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
# Purpose

Strict package managers like pnpm, yarn in pnp or pnpm mode won't allow next-secure-headers to access react.

So here's a fix. I've added react as dependency with a large range (16, 17 and 18). 

For @types/node as it's seems only internal and typescript only, I just added them as an optional peerDependency... But it's not required, so I can remove it if you feel so.

By the way, thanks for this great lib.


PS:

As a workaround for yarn 2 or 3, it's possible to add the following in the yarnrc.yml

```yml
packageExtensions:
  "next-secure-headers@*":
    peerDependencies:
      react: ^17.0.0
```